### PR TITLE
replace processRowUpdate argument with corrected type

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,6 @@ import {
   GridActionsCellItem,
   GridEventListener,
   GridRowId,
-  GridRowModel,
 } from "@mui/x-data-grid";
 import useLocalStorageState from "use-local-storage-state";
 import EditToolbar from "@/components/EditToolbar";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "@mui/x-data-grid";
 import useLocalStorageState from "use-local-storage-state";
 import EditToolbar from "@/components/EditToolbar";
+import { Row } from "@/types";
 
 export default function Home() {
   const [rows, setRows] = useLocalStorageState("rows", {
@@ -62,12 +63,9 @@ export default function Home() {
     });
   };
 
-  const processRowUpdate = (newRow: GridRowModel) => {
-    const updatedRow = newRow;
-    // @ts-ignore
-    //setRows updates the local storage persisted state row if it exists
-    setRows(rows.map((row) => (row.id === newRow.id ? updatedRow : row)));
-    return updatedRow;
+  const processRowUpdate = (newRow: Row) => {
+    setRows(rows.map((row) => (row.id === newRow.id ? newRow : row)));
+    return newRow;
   };
 
   const columns: GridColumns = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,3 +6,12 @@ export interface EditToolbarProps {
     newModel: (oldModel: GridRowModesModel) => GridRowModesModel
   ) => void;
 }
+
+export interface Row {
+  id: string;
+  firstName: string;
+  lastName: string;
+  jobTitle: string;
+  departmentId: string;
+  managerId?: string;
+}


### PR DESCRIPTION
Fixes a type match error in the processRowUpdate function between the rows array and the elements produced by the map function. I replaced the processRowUpdate argument with a custom corrected type.